### PR TITLE
upgrade to reason-react@0.2.4

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,7 +3,7 @@
   "bsc-flags": ["-bs-super-errors"],
   "reason": {"react-jsx" : 2},
   "bs-dependencies": ["reason-react"],
-  "bs-dev-dependencies": ["reason-js", "immutable-re"],
+  "bs-dev-dependencies": ["immutable-re"],
   "sources": [
     "src",
     {

--- a/examples/immutable/immutableRenderer.re
+++ b/examples/immutable/immutableRenderer.re
@@ -10,7 +10,7 @@ let make state::(state: AppState.appState) ::dispatch _children => {
     };
   let incrementAsync store =>
     ignore (
-      ReasonJs.setTimeout
+      Js.Global.setTimeout
         (
           fun () =>
             Reductive.Store.dispatch store (TimeTravelStore.CounterAction SimpleStore.Increment)

--- a/examples/react/dataRenderer.re
+++ b/examples/react/dataRenderer.re
@@ -10,7 +10,7 @@ let make state::(state: ThunkedStore.appState) ::dispatch _children => {
     };
   let incrementAsync store =>
     ignore (
-      ReasonJs.setTimeout
+      Js.Global.setTimeout
         (
           fun () =>
             Reductive.Store.dispatch store (ThunkedStore.CounterAction SimpleStore.Increment)

--- a/package.json
+++ b/package.json
@@ -18,14 +18,13 @@
   "author": "rickyvetter",
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "^1.9.0",
+    "bs-platform": "^1.9.1",
     "immutable-re": "https://github.com/facebookincubator/immutable-re.git",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "reason-js": "0.0.16",
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "reason-react": "^0.2.3"
+    "reason-react": "^0.2.4"
   }
 }

--- a/src/reductive.re
+++ b/src/reductive.re
@@ -45,17 +45,17 @@ module Provider = {
     unsubscribe: option (unit => unit)
   };
   let createMake ::name="Provider" (store: Store.t 'action 'state) => {
-    let innerComponent = ReasonReact.statefulComponent name;
+    let innerComponent = ReasonReact.reducerComponent name;
     let make
         component::(
           component:
             state::'state =>
             dispatch::('action => unit) =>
             array ReasonReact.reactElement =>
-            ReasonReact.component 'a 'b
+            ReasonReact.component 'a 'b 'c
         )
         (_children: array ReasonReact.reactElement)
-        :ReasonReact.component (state 'state) ReasonReact.noRetainedProps => {
+        :ReasonReact.component (state 'state) ReasonReact.noRetainedProps ReasonReact.actionless => {
       let updater _ {ReasonReact.state: state} =>
         ReasonReact.Update {...state, reductiveState: Some (Store.getState store)};
       {

--- a/src/reductive.rei
+++ b/src/reductive.rei
@@ -24,10 +24,10 @@ module Provider: {
       state::'state =>
       dispatch::('action => unit) =>
       array ReasonReact.reactElement =>
-      ReasonReact.component 'a 'b
+      ReasonReact.component 'a 'b 'c
     ) =>
     array ReasonReact.reactElement =>
-    ReasonReact.component (state 'state) ReasonReact.noRetainedProps;
+    ReasonReact.component (state 'state) ReasonReact.noRetainedProps ReasonReact.actionless;
 };
 
 


### PR DESCRIPTION
and deprecates reason-js

Please check that it is correct to use ```ReasonReact.actionless``` as I am not certain what it should be.