### PR TITLE
initialize store state to support renderToString

### DIFF
--- a/src/reductive.re
+++ b/src/reductive.re
@@ -57,7 +57,7 @@ module Provider = {
         )
         : ReasonReact.component(state('state), ReasonReact.noRetainedProps, action) => {
       ...innerComponent,
-      initialState: () => {reductiveState: None, unsubscribe: None},
+      initialState: () => {reductiveState: Some(Store.getState(store)), unsubscribe: None},
       reducer: (action, state) =>
         switch action {
         | UpdateState =>


### PR DESCRIPTION
Since renderToString is called without access to the DOM, componentDidMount never fires so the component never gets initial state. This fixed it with my local test and doesn't break any of the tests already created. Anything else I can do to ensure robustness here?