### PR TITLE
Type definitions

### DIFF
--- a/src/reductive.re
+++ b/src/reductive.re
@@ -133,3 +133,25 @@ let applyMiddleware = _ => ();
 
 let bindActionCreators = (actions, dispatch) =>
   List.map((action, ()) => dispatch(action), actions);
+
+type store('action, 'state) = Store.t('action, 'state);
+type reducer('action, 'state) = ('state, 'action) => 'state;
+
+type middleware('action, 'state) =
+  (store('action, 'state), 'action => unit, 'action) => unit;
+
+type storeCreator('action, 'origin, 'state) =
+  (
+    ~reducer: reducer('action, 'origin),
+    ~preloadedState: 'state,
+    ~enhancer: middleware('action, 'state)=?,
+    unit
+  ) =>
+  store('action, 'state);
+
+type storeEnhancer('action, 'origin, 'state) =
+  storeCreator('action, 'origin, 'state) =>
+  storeCreator('action, 'origin, 'state);
+
+type applyMiddleware('action, 'origin, 'state) =
+  middleware('action, 'state) => storeEnhancer('action, 'origin, 'state);

--- a/src/reductive.rei
+++ b/src/reductive.rei
@@ -130,3 +130,25 @@ Instead - you are free to build the action data type at dispatch time.
 |}
 ]
 let bindActionCreators: (list('a), 'a => 'b) => list(unit => 'b);
+
+type store('action, 'state) = Store.t('action, 'state);
+type reducer('action, 'state) = ('state, 'action) => 'state;
+
+type middleware('action, 'state) =
+  (store('action, 'state), 'action => unit, 'action) => unit;
+
+type storeCreator('action, 'origin, 'state) =
+  (
+    ~reducer: reducer('action, 'origin),
+    ~preloadedState: 'state,
+    ~enhancer: middleware('action, 'state)=?,
+    unit
+  ) =>
+  store('action, 'state);
+
+type storeEnhancer('action, 'origin, 'state) =
+  storeCreator('action, 'origin, 'state) =>
+  storeCreator('action, 'origin, 'state);
+
+type applyMiddleware('action, 'origin, 'state) =
+  middleware('action, 'state) => storeEnhancer('action, 'origin, 'state);


### PR DESCRIPTION
Adds type definitions discussed in #24, however with difference in following definitions: 

```reason
type storeCreator('action, 'origin, 'state) =
  (
    ~reducer: reducer('action, 'origin),
    ~preloadedState: 'state,
    ~enhancer: middleware('action, 'state)=?,
    unit
  ) =>
  store('action, 'state);

type storeEnhancer('action, 'origin, 'state) =
  storeCreator('action, 'origin, 'state) =>
  storeCreator('action, 'origin, 'state);

type applyMiddleware('action, 'origin, 'state) =
  middleware('action, 'state) => storeEnhancer('action, 'origin, 'state);
```

Additional type parameter `'origin` accounts for the scenario when storeEnhancer applies composition (decorates original store with higher level state and reducer - hope my wording is correct here), where real-world example looks the following way:

Enhancer to wrap ReactReason router:

```reason
let enhancer = (storeCreator: storeCreator('action, 'origin, 'state)) => (~reducer, ~preloadedState, ~enhancer=?, ()) => {
  let routerReducer = (state, action) => 
    switch(action){
    | `RouterLocationChanged(route: ReasonReact.Router.url) => { ...state, route }
    | _ => {
      ...state,
      state: reducer(state.state, action)
    }};
  
  let interceptPushRoute = (store, next, action) => 
    switch(action, enhancer){
    | (`RouterPushRoute(path), _) => ReasonReact.Router.push(path);
    | (_, Some(enhancer)) => enhancer(store, next, action)
    | (_, None) => next(action)
    };
  
  let store = storeCreator(~reducer=routerReducer, ~preloadedState, ~enhancer=interceptPushRoute, ());
  let _watcherId = ReasonReact.Router.watchUrl(url => Reductive.Store.dispatch(store, `RouterLocationChanged(url)));
  store
};

```

which is used in store defined like:

```reason
let storeCreator = devToolsEnhancer @@ ReductiveRouter.enhancer @@ Reductive.Store.create;
let store = storeCreator(
  ~reducer=appReducer,
  ~preloadedState={
    route: {
      path: [],
      hash: "",
      search: ""
    },
    state: {
      counter: 0, 
      content: ""
    },
  },
  (),
);
```

storeCreator in this case is passed with an original reducer - sub-reducer in our resulting decorated store.