### PR TITLE
Use store from Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ module AppStore = {
 
 This will create a "typed" version of the store context and hooks with the `action` and `state` types specific to your application. If you are curious, `ReductiveContext.Make` is called a [functor](https://reasonml.github.io/docs/en/module#module-functions-functors), which is a module that acts as a function, and can be used to make custom versions of a module for different data structures.
 
-Finally, use the provider from `AppStore` when rendering your root component:
+Finally, use the provider from `AppStore` when rendering your root component passing in the created `store`:
 
 ```reason
 ReactDOMRe.renderToElementWithId(
-  <AppStore.Provider> <Root /> </AppStore.Provider>,
+  <AppStore.Provider store=appStore> <Root /> </AppStore.Provider>,
   "root",
 );
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Subscribes to changes to a selected portion of the store state, specified by a s
 
 `useSelector` is built on top of the [`useSubscription`](https://github.com/facebook/react/tree/master/packages/use-subscription) hook, which is [safe to use](https://github.com/facebook/react/tree/master/packages/use-subscription#limitations-in-concurrent-mode) in the concurrent mode.
 
+### useStore
+This hook returns a reference to the store that was passed in to the `<Provider>` component.
+
+This hook should probably not be used frequently. Prefer `useSelector()` as your primary choice. However, this may be useful for less common scenarios that do require access to the store, such as replacing reducers.
+
 #### Selector function
 
 The selector function is required to have a **stable reference** in order to avoid infinite re-renders. The easiest to achieve this is to declare it outside of the component,

--- a/__tests__/reductiveContext_test.re
+++ b/__tests__/reductiveContext_test.re
@@ -35,7 +35,6 @@ module TestStoreContext = {
   include ReductiveContext.Make({
     type action = testAction;
     type state = testState;
-    let store = appStore;
   });
 };
 

--- a/__tests__/reductiveContext_test.re
+++ b/__tests__/reductiveContext_test.re
@@ -42,7 +42,9 @@ module TestStoreContext = {
 module App = {
   [@react.component]
   let make = (~children) => {
-    <TestStoreContext.Provider> children </TestStoreContext.Provider>;
+    <TestStoreContext.Provider store=TestStoreContext.appStore>
+      children
+    </TestStoreContext.Provider>;
   };
 };
 

--- a/examples/immutable/immutableEntry.re
+++ b/examples/immutable/immutableEntry.re
@@ -1,5 +1,7 @@
-[@bs.config {jsx:3}];
+[@bs.config {jsx: 3}];
 ReactDOMRe.renderToElementWithId(
-  <TimeTravelStore.Provider> <ImmutableRenderer /> </TimeTravelStore.Provider>,
+  <TimeTravelStore.Provider store=TimeTravelStore.timeTravelStore>
+    <ImmutableRenderer />
+  </TimeTravelStore.Provider>,
   "index",
 );

--- a/examples/immutable/timeTravelStore.re
+++ b/examples/immutable/timeTravelStore.re
@@ -91,6 +91,4 @@ let timeTravelStore =
 include ReductiveContext.Make({
   type action = ReduxThunk.thunk(AppState.appState);
   type state = AppState.appState;
-
-  let store = timeTravelStore;
 });

--- a/examples/react/reactEntry.re
+++ b/examples/react/reactEntry.re
@@ -1,5 +1,7 @@
 [@bs.config {jsx: 3}];
 ReactDOMRe.renderToElementWithId(
-  <ThunkedStore.Provider> <DataRenderer /> </ThunkedStore.Provider>,
+  <ThunkedStore.Provider store=ThunkedStore.appStore>
+    <DataRenderer />
+  </ThunkedStore.Provider>,
   "index",
 );

--- a/examples/react/thunkedStore.re
+++ b/examples/react/thunkedStore.re
@@ -40,6 +40,4 @@ let appStore =
 include ReductiveContext.Make({
   type state = appState;
   type action = ReduxThunk.thunk(appState);
-
-  let store = appStore;
 });

--- a/examples/render/renderEntry.re
+++ b/examples/render/renderEntry.re
@@ -63,8 +63,6 @@ module AppStore = {
   include ReductiveContext.Make({
     type state = appState;
     type action = ReduxThunk.thunk(appState);
-
-    let store = appStore;
   });
 };
 

--- a/examples/todomvc/todomvcEntry.re
+++ b/examples/todomvc/todomvcEntry.re
@@ -86,8 +86,6 @@ module AppStore = {
   include ReductiveContext.Make({
     type action = appAction;
     type state = appState;
-
-    let store = appStore;
   });
 };
 

--- a/examples/todomvc/todomvcEntry.re
+++ b/examples/todomvc/todomvcEntry.re
@@ -335,6 +335,6 @@ module App = {
 };
 
 ReactDOMRe.renderToElementWithId(
-  <AppStore.Provider> <App /> </AppStore.Provider>,
+  <AppStore.Provider store=appStore> <App /> </AppStore.Provider>,
   "TodoApp",
 );

--- a/src/reductiveContext.re
+++ b/src/reductiveContext.re
@@ -2,8 +2,6 @@
 module type Config = {
   type state;
   type action;
-
-  let store: Reductive.Store.t(action, state);
 };
 
 module Make = (Config: Config) => {

--- a/src/reductiveContext.re
+++ b/src/reductiveContext.re
@@ -62,5 +62,20 @@ module Make = (Config: Config) => {
   let useDispatch = () => {
     Reductive.Store.dispatch(getStoreFromContext());
   };
+
+  let useStore = () => {
+    let store = getStoreFromContext();
+
+    let source =
+      React.useMemo1(
+        () =>
+          {
+            subscribe: Reductive.Store.subscribe(store),
+            getCurrentValue: () => store,
+          },
+        [|store|],
+      );
+
+    useSubscription(source);
   };
 };

--- a/src/reductiveContext.re
+++ b/src/reductiveContext.re
@@ -30,26 +30,26 @@ module Make = (Config: Config) => {
     };
   };
 
-  let getStoreFromContext = () => {
-    switch (React.useContext(storeContext)) {
+  let useStore = () => {
+    let storeFromContext = React.useContext(storeContext);
+    switch (storeFromContext) {
     | None =>
       failwith(
         "could not find reactive context value; please ensure the component is wrapped in a <Provider>",
       )
-    | Some(storeContext) => storeContext
+    | Some(store) => store
     };
   };
 
   let useSelector = selector => {
-    let store = getStoreFromContext();
+    let store = useStore();
 
     let source =
       React.useMemo2(
         () =>
           {
             subscribe: Reductive.Store.subscribe(store),
-            getCurrentValue: () =>
-              selector(Reductive.Store.getState(store)),
+            getCurrentValue: () => selector(Reductive.Store.getState(store)),
           },
         (selector, store),
       );
@@ -60,22 +60,6 @@ module Make = (Config: Config) => {
   };
 
   let useDispatch = () => {
-    Reductive.Store.dispatch(getStoreFromContext());
-  };
-
-  let useStore = () => {
-    let store = getStoreFromContext();
-
-    let source =
-      React.useMemo1(
-        () =>
-          {
-            subscribe: Reductive.Store.subscribe(store),
-            getCurrentValue: () => store,
-          },
-        [|store|],
-      );
-
-    useSubscription(source);
+    Reductive.Store.dispatch(useStore());
   };
 };

--- a/src/reductiveContext.re
+++ b/src/reductiveContext.re
@@ -35,7 +35,7 @@ module Make = (Config: Config) => {
     switch (storeFromContext) {
     | None =>
       failwith(
-        "could not find reactive context value; please ensure the component is wrapped in a <Provider>",
+        "Could not find reductive context value; please ensure the component is wrapped in a <Provider>",
       )
     | Some(store) => store
     };

--- a/src/reductiveContext.rei
+++ b/src/reductiveContext.rei
@@ -9,10 +9,25 @@ module Make:
     module Provider: {
       [@bs.obj]
       external makeProps:
-        (~children: 'children, ~key: string=?, unit) =>
-        {. "children": 'children} =
+        (
+          ~children: 'children,
+          ~store: Reductive.Store.t(Config.action, Config.state),
+          ~key: string=?,
+          unit
+        ) =>
+        {
+          .
+          "children": 'children,
+          "store": Reductive.Store.t(Config.action, Config.state),
+        } =
         "";
-      let make: {. "children": React.element} => React.element;
+      let make:
+        {
+          .
+          "children": React.element,
+          "store": Reductive.Store.t(Config.action, Config.state),
+        } =>
+        React.element;
     };
     let useSelector: (Config.state => 'selectedState) => 'selectedState;
     let useDispatch: (unit, Config.action) => unit;

--- a/src/reductiveContext.rei
+++ b/src/reductiveContext.rei
@@ -31,4 +31,5 @@ module Make:
     };
     let useSelector: (Config.state => 'selectedState) => 'selectedState;
     let useDispatch: (unit, Config.action) => unit;
+    let useStore: unit => Reductive.Store.t(Config.action, Config.state);
   };

--- a/src/reductiveContext.rei
+++ b/src/reductiveContext.rei
@@ -1,7 +1,6 @@
 module type Config = {
   type state;
   type action;
-  let store: Reductive.Store.t(action, state);
 };
 module Make:
   (Config: Config) =>


### PR DESCRIPTION
This PR addresses this issue: ReductiveContext doesn't use the value provided by the ContextProvider #48.

With this PR we require a `store` prop when using the `Provider` component
```reason
<AppStore.Provider store=AppStore.store> <App /> </AppStore.Provider>
```
The context is created with an invalid value `None` so that we can return an error if its value hasn't been updated with a valid store.

Finally it adds the `useStore` hook.