### PR TITLE
Use callback to make sure dispatch function is stable

### DIFF
--- a/src/reductiveContext.re
+++ b/src/reductiveContext.re
@@ -58,6 +58,7 @@ module Make = (Config: Config) => {
   };
 
   let useDispatch = () => {
-    Reductive.Store.dispatch(useStore());
+    let store = useStore();
+    React.useCallback1(Reductive.Store.dispatch(store), [|store|]);
   };
 };


### PR DESCRIPTION
Fixed #51 by using `useCallback` around `dispatch` with `store` as dependency.