### PR TITLE
Type definitions 

### DIFF
--- a/src/reductive.re
+++ b/src/reductive.re
@@ -135,3 +135,30 @@ let applyMiddleware = _ => ();
 
 let bindActionCreators = (actions, dispatch) =>
   List.map((action, ()) => dispatch(action), actions);
+
+type store('action, 'state) = Store.t('action, 'state);
+type reducer('action, 'state) = ('state, 'action) => 'state;
+
+type middleware('action, 'state) =
+  (store('action, 'state), 'action => unit, 'action) => unit;
+
+type storeCreator('action, 'state) =
+  (
+    ~reducer: reducer('action, 'state),
+    ~preloadedState: 'state,
+    ~enhancer: middleware('action, 'state)=?,
+    unit
+  ) =>
+  store('action, 'state);
+
+type storeEnhancer('action, 'state) =
+  storeCreator('action, 'state) => storeCreator('action, 'state);
+
+type liftedStoreEnhancer('action, 'state, 'enhancedAction, 'enhancedState) =
+  (
+    ~reducer: reducer('action, 'state),
+    ~preloadedState: 'enhancedState,
+    ~enhancer: middleware('enhancedAction, 'enhancedState)=?,
+    unit
+  ) =>
+  store('enhancedAction, 'enhancedState);

--- a/src/reductive.rei
+++ b/src/reductive.rei
@@ -134,3 +134,30 @@ Instead - you are free to build the action data type at dispatch time.
 |}
 ]
 let bindActionCreators: (list('a), 'a => 'b) => list(unit => 'b);
+
+type store('action, 'state) = Store.t('action, 'state);
+type reducer('action, 'state) = ('state, 'action) => 'state;
+
+type middleware('action, 'state) =
+  (store('action, 'state), 'action => unit, 'action) => unit;
+
+type storeCreator('action, 'state) =
+  (
+    ~reducer: reducer('action, 'state),
+    ~preloadedState: 'state,
+    ~enhancer: middleware('action, 'state)=?,
+    unit
+  ) =>
+  store('action, 'state);
+
+type storeEnhancer('action, 'state) =
+  storeCreator('action, 'state) => storeCreator('action, 'state);
+
+type liftedStoreEnhancer('action, 'state, 'enhancedAction, 'enhancedState) =
+  (
+    ~reducer: reducer('action, 'state),
+    ~preloadedState: 'enhancedState,
+    ~enhancer: middleware('enhancedAction, 'enhancedState)=?,
+    unit
+  ) =>
+  store('enhancedAction, 'enhancedState);


### PR DESCRIPTION
**Issue**
https://github.com/reasonml-community/reductive/issues/24, (revamp of https://github.com/reasonml-community/reductive/pull/42)

**Description of changes**
Adds type definitions discussed in https://github.com/reasonml-community/reductive/issues/24, also adds `liftedStoreEnhancer` for store composion (a.k.a lifting) usecase.

**Purpose**
Add clarify to types used in reductive. 

**Additional info**:
I feel `liftedStoreEnhancer` deserves explanation. Existing mechanisms for composition in reductive are:
1. middleware (enhancer parameter in `createStore`): alters the behavior of the `dispatch`.
2. store enhancer (`storeCreator` composition): adds sugar to a store creator. Often used to hook external sources to dispatch action to the store.

The 'classical' `storeEnhancer` has a signature 

```reason
type storeEnhancer('action, 'state) =
  storeCreator('action, 'state) => storeCreator('action, 'state);
```

While it allows to manipulate initial state and reducer, the resulting state creator state type is same as original's which does not allow to support composition. Composition gets handy when we want to compose multiple redux apps together, the definition is:

```reason
type liftedStoreEnhancer('action, 'state, 'enhancedAction, 'enhancedState) =
  (
    ~reducer: reducer('action, 'state),
    ~preloadedState: 'enhancedState,
    ~enhancer: middleware('enhancedAction, 'enhancedState)=?,
    unit
  ) =>
  store('enhancedAction, 'enhancedState);
```

Hypothetical example:
Let's use composite to isolate routing and localization from the core business logic.

```reason
module BaseState = {
  type t = {
    session: string
  };
};

type state = ReductiveLocale.withLocale(
  ReductiveRouter.withRouter(
    BaseState.t
  )
);

module Action = {
  type t = [
    | `DummySetSession(string) 
    | `DevToolsUpdate(state)
    | ReductiveRouter.routerActions
    | ReductiveLocale.localeActions
  ];
};

let initial: state = {
  locale: Locale.En,
  state: {
    route: ReductiveRouter.initialRoute,
    state: {
      session: ""
    }
  }
};

let storeCreator: Reductive.liftedStoreEnhancer(Action.t, BaseState.t, Action.t, state) = 
  ReductiveRouter.enhancer 
  @@ ReductiveLocale.enhancer 
  @@ devToolsEnhancer 
  @@ Reductive.Store.create;

let store = storeCreator(
  ~reducer=Reducers.root, 
  ~preloadedState=initial, 
  ~enhancer=ReductiveObservable.middleware(epicFeeder |. Rx.BehaviorSubject.asObservable), 
  ())
```

above store creator 'lifts' original reducer with a chain of higher-order-reducers about it, and supplies the resulting lifted initial state.

**Reducers.re**:
```reason
let root = (
  state: State.t, 
  action
) => 
  switch(action){
  | `DummySetSession(sessionDummy) => {
    ...state,
    session: sessionDummy ++ "DUMMY"
  }
  | _ => state
  };
```

Lifted store enhancers are respectfully defined as:

**ReductiveRouter.re**
```reason
type withRouter('state) = {
  route: ReasonReact.Router.url,
  state: 'state
};

type routerActions = [
  | `RouterLocationChanged(ReasonReact.Router.url)
  | `RouterPushRoute(string)
];

let initialRoute = ReasonReact.Router.dangerouslyGetInitialUrl();

let routerReducer = reducer => (state, action) => 
  switch(action){
  | `RouterLocationChanged(route) => { 
    ...state, 
    route
  }
  | _ => {
    ...state,
    state: reducer(state.state, action)
  }};

let interceptPushRoute = (store, next, action) => {
  next(action);
  switch(action){
  | `RouterPushRoute(path) => ReasonReact.Router.push(path)
  | _ => ()
  };
}

let enhancer = storeCreator => (~reducer, ~preloadedState, ~enhancer=?, ()) => { 
  let store = storeCreator(
    ~reducer = routerReducer @@ reducer, 
    ~preloadedState, 
    ~enhancer=?Some(
      enhancer
      |. Belt.Option.mapWithDefault(
        interceptPushRoute,
        middleware => ((store, next) => interceptPushRoute(store) @@ middleware(store) @@ next)
      )),
    ());

  ReasonReact.Router.watchUrl(url => 
    Reductive.Store.dispatch(
      store, 
      `RouterLocationChanged({ ...url, path: url.path })
  )) |> ignore;
  
  store
};
```

**ReductiveLocale.re**
```reason
type withLocale('state) = {
  locale: Locale.locale,
  state: 'state
};

type localeActions = [
  `SetLocale(Locale.locale)
];

let localeReducer = reducer => (state, action) =>
  switch(action){
  | `SetLocale(locale) => {...state, locale }
  | _ => {...state, state: reducer(state.state, action)}
  };

let enhancer = (storeCreator) => (~reducer, ~preloadedState, ~enhancer=?, ()) =>
  storeCreator(
    ~reducer=localeReducer @@ reducer, 
    ~preloadedState, 
    ~enhancer?,
    ());
```

@MargaretKrutikova: what do you think?