### PR TITLE
Upgrade JSX version to v3 for upgrades to Bucklescript v8

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,7 @@
     "-bs-super-errors"
   ],
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "bs-dependencies": [
     "reason-react"

--- a/examples/render-v2/renderEntryV2.re
+++ b/examples/render-v2/renderEntryV2.re
@@ -5,116 +5,121 @@
  * updates" feature to see this in action. If that proves difficult, then
  * try the Chrome devtools Rendering options, enabling "Paint flashing".
  */
-type counterAction =
-  | Increment
-  | Decrement;
 
-let counterReduce = (state, action) =>
-  switch (action) {
-  | Increment => state + 1
-  | Decrement => state - 1
-  };
+module Counter = {
+  type counterAction =
+    | Increment
+    | Decrement;
 
-type stringAction =
-  | AppendA
-  | AppendB;
-
-let stringReduce = (state, action) =>
-  switch (action) {
-  | AppendA => state ++ "A"
-  | AppendB => state ++ "B"
-  };
-
-type ReduxThunk.thunk(_) +=
-  | StringAction(stringAction)
-  | CounterAction(counterAction);
-
-type appState = {
-  counter: int,
-  content: string,
+  let counterReduce = (state, action) =>
+    switch (action) {
+    | Increment => state + 1
+    | Decrement => state - 1
+    };
 };
 
-let appReducer = (state, action) =>
-  switch (action) {
-  | StringAction(action) => {
-      ...state,
-      content: stringReduce(state.content, action),
-    }
-  | CounterAction(action) => {
-      ...state,
-      counter: counterReduce(state.counter, action),
-    }
-  | _ => state
-  };
+module Content = {
+  type contentAction =
+    | AppendA
+    | AppendB;
 
-let thunkedLogger = (store, next) =>
-  Middleware.thunk(store) @@ Middleware.logger(store) @@ next;
-
-let store =
-  Reductive.Store.create(
-    ~reducer=appReducer,
-    ~preloadedState={counter: 0, content: ""},
-    ~enhancer=thunkedLogger,
-    (),
-  );
-
-module StringProvider = {
-  let make = Reductive.Lense.createMake(~lense=s => s.content, store);
+  let contentReduce = (state, action) =>
+    switch (action) {
+    | AppendA => state ++ "A"
+    | AppendB => state ++ "B"
+    };
 };
 
-module StringComponent = {
-  let component =
-    ReasonReact.statelessComponentWithRetainedProps("StringComponent");
-  let make = (~state: string, ~dispatch, _children) => {
-    ...component,
-    ReasonReact.retainedProps: state,
-    render: _self =>
-      <div>
-        <div> {ReasonReact.string("Content: " ++ state)} </div>
-        <button onClick={_ => dispatch(StringAction(AppendA))}>
-          {ReasonReact.string("+A")}
-        </button>
-        <button onClick={_ => dispatch(StringAction(AppendB))}>
-          {ReasonReact.string("+B")}
-        </button>
-      </div>,
+module App = {
+  type appState = {
+    counter: int,
+    content: string,
+  };
+
+  type appAction =
+    | CounterAction(Counter.counterAction)
+    | StringAction(Content.contentAction);
+
+  let appReducer = (state, action) =>
+    switch (action) {
+    | StringAction(action) => {
+        ...state,
+        content: Content.contentReduce(state.content, action),
+      }
+    | CounterAction(action) => {
+        ...state,
+        counter: Counter.counterReduce(state.counter, action),
+      }
+    };
+};
+
+module Store = {
+  include ReductiveContext.Make({
+    type action = App.appAction;
+    type state = App.appState;
+  });
+
+  let logger = (store, next) => Middleware.logger(store) @@ next;
+
+  let store =
+    Reductive.Store.create(
+      ~reducer=App.appReducer,
+      ~preloadedState={counter: 0, content: ""},
+      ~enhancer=logger,
+      (),
+    );
+
+  module Selectors = {
+    open App;
+    let state = state => state;
+    let contentState = state => state.content;
+    let counterState = state => state.counter;
   };
 };
 
-module CounterProvider = {
-  let make = Reductive.Lense.createMake(~lense=s => s.counter, store);
+module ContentComponent = {
+  [@react.component]
+  let make = () => {
+    let dispatch = Store.useDispatch();
+    let state = Store.useSelector(Store.Selectors.contentState);
+    <div>
+      <div> {ReasonReact.string("Content: " ++ state)} </div>
+      <button onClick={_ => dispatch(StringAction(AppendA))}>
+        {ReasonReact.string("+A")}
+      </button>
+      <button onClick={_ => dispatch(StringAction(AppendB))}>
+        {ReasonReact.string("+B")}
+      </button>
+    </div>;
+  };
 };
 
 module CounterComponent = {
-  let component =
-    ReasonReact.statelessComponentWithRetainedProps("CounterComponent");
-  let make = (~state: int, ~dispatch, _children) => {
-    ...component,
-    ReasonReact.retainedProps: state,
-    render: _self =>
-      <div>
-        <div>
-          {ReasonReact.string("Counter: " ++ string_of_int(state))}
-        </div>
-        <button onClick={_ => dispatch(CounterAction(Increment))}>
-          {ReasonReact.string("++")}
-        </button>
-        <button onClick={_ => dispatch(CounterAction(Decrement))}>
-          {ReasonReact.string("--")}
-        </button>
-      </div>,
+  [@react.component]
+  let make = () => {
+    let dispatch = Store.useDispatch();
+    let state = Store.useSelector(Store.Selectors.counterState);
+    <div>
+      <div> {React.string("Counter: " ++ string_of_int(state))} </div>
+      <button onClick={_ => dispatch(CounterAction(Increment))}>
+        {React.string("++")}
+      </button>
+      <button onClick={_ => dispatch(CounterAction(Decrement))}>
+        {React.string("--")}
+      </button>
+    </div>;
   };
 };
 
 module RenderApp = {
-  let component = ReasonReact.statelessComponent("RenderApp");
-  let make = _children => {
-    ...component,
-    render: _self =>
-      <div>
-        <CounterProvider component=CounterComponent.make />
-        <StringProvider component=StringComponent.make />
-      </div>,
+  [@react.component]
+  let make = () => {
+    <div>
+      <Store.Provider store=Store.store>
+        <CounterComponent />
+        <ContentComponent />
+      </Store.Provider>
+    </div>;
   };
 };
 


### PR DESCRIPTION
This should fix https://github.com/reasonml-community/reductive/issues/60

It seems the only thing needed was a bump in the version spec and a rewrite on one of the examples. To make the example slightly clearer / more readable I moved a thing or two into a module here and there. More like one would have in an actual project.
The only thing I removed was the Thunks as I'm unfamiliar with the typing there. It seems that it also adds complexity to the example where it shouldn't.